### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for weekly `uv` dependency updates.
- Group Python dependency updates together to reduce Dependabot PR noise.

## Validation
- Ran a basic sanity check confirming the config targets the root `uv` project.

Closes #10.
