### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Python tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run tests
+        run: uv run pytest

--- a/scrape.py
+++ b/scrape.py
@@ -15,7 +15,7 @@ parser.add_argument(
     "--clean", help="discard any previous cached html", action="store_true"
 )
 parser.add_argument("--single", help="run on a single film url", action="store")
-args = parser.parse_args()
+args = argparse.Namespace(clean=False, single=None)
 
 logging.basicConfig()
 log = logging.getLogger()
@@ -25,7 +25,7 @@ err_handler = logging.FileHandler("errors.log")
 err_handler.setLevel(logging.ERROR)
 log.addHandler(err_handler)
 
-output_file = open("clashfinder", "w")
+output_file = None
 
 BASE_URL = "https://www.leedsfilm.com"
 DATE_FORMAT_IN = "%a %d %b %Y %H:%M"  # Fri 6 Nov 2022 13:15
@@ -251,12 +251,13 @@ def remap_venue(venue: str) -> str:
 
 
 if __name__ == "__main__":
-    if args.single:
-        cx = sqlite3.connect("html.db")
-        handle_film(args.single, cx)
-    else:
-        go()
-output_file.close()
+    args = parser.parse_args()
+    with open("clashfinder", "w") as output_file:
+        if args.single:
+            cx = sqlite3.connect("html.db")
+            handle_film(args.single, cx)
+        else:
+            go()
 
 for x in all_lengths:
     log.debug(x)


### PR DESCRIPTION
Closes #14.

## Summary
- Added a GitHub Actions workflow that runs on pushes to `master`, PRs targeting `master`, and manual dispatch.
- The workflow installs dependencies with `uv sync --locked` and runs the test suite with `uv run pytest`.
- Made `scrape.py` safe to import under test runners by parsing CLI args only when the script is executed directly, and by only opening `clashfinder` during direct CLI runs.

## Tests
- `uv sync --locked`
- `uv run pytest`

Current test coverage is the 3 existing tests in `tests/test_scrape.py`:
- checks the saved LIFF listing fixture contains 54 film links
- checks venue remapping for an Everyman screen
- checks `handle_film` parses the Bugonia fixture into four Clashfinder output rows with the expected title, venue, start, and end times

## Coverage notes
The current tests are useful smoke coverage for the scraper, but a few more would help. The most valuable additions would be tests for `build_date_range`/runtime edge cases, missing or oddly formatted film metadata, cache behaviour in `retrieve_film`, and the ticket-splitting PDF path.
